### PR TITLE
[fix] check future status before set_result

### DIFF
--- a/wsrpc_aiohttp/websocket/common.py
+++ b/wsrpc_aiohttp/websocket/common.py
@@ -180,8 +180,9 @@ class WSRPCBase:
 
     async def handle_result(self, serial, result):
         cb = self._futures.pop(serial, None)
-        if not cb.done():
-            cb.set_result(result)
+        if not cb or cb.done():
+            return
+        cb.set_result(result)
 
     async def handle_error(self, serial, error):
         self._reject(serial, error)

--- a/wsrpc_aiohttp/websocket/common.py
+++ b/wsrpc_aiohttp/websocket/common.py
@@ -180,7 +180,8 @@ class WSRPCBase:
 
     async def handle_result(self, serial, result):
         cb = self._futures.pop(serial, None)
-        cb.set_result(result)
+        if not cb.done():
+            cb.set_result(result)
 
     async def handle_error(self, serial, error):
         self._reject(serial, error)


### PR DESCRIPTION
canceled future on timeout in 2.4.4 cause error on set_result