### PR TITLE
Proxy explicitly in WebSocketRoute

### DIFF
--- a/wsrpc_aiohttp/websocket/common.py
+++ b/wsrpc_aiohttp/websocket/common.py
@@ -11,7 +11,7 @@ from typing import Union, Callable, Any, Dict, Mapping
 import aiohttp
 
 from .tools import loads
-from .route import WebSocketRoute
+from .route import WebSocketRoute, decorators
 
 
 class ClientException(Exception):
@@ -388,6 +388,9 @@ class WSRPCBase:
 
         """
         assert callable(handler) or isinstance(handler, WebSocketRoute)
+        if callable(handler):
+            handler = decorators.proxy(handler)
+
         cls.get_routes()[route] = handler
 
     def add_event_listener(self, func: Callable[[dict], Any]):

--- a/wsrpc_aiohttp/websocket/route.py
+++ b/wsrpc_aiohttp/websocket/route.py
@@ -1,14 +1,21 @@
 import logging
 
 import asyncio
+from abc import ABC, abstractmethod
+
 from . import handler       # noqa
 
 log = logging.getLogger("wsrpc")
 
 
-class decorators:
-
+class decorators(object):
+    _NOPROXY = set([])
     _PROXY_ATTR = '__wsrpc_aiohttp_proxy__'
+
+    @staticmethod
+    def noproxy(func):
+        decorators._NOPROXY.add(func)
+        return func
 
     @staticmethod
     def proxy(f):
@@ -20,34 +27,64 @@ class decorators:
         return getattr(f, decorators._PROXY_ATTR, False)
 
 
-class WebSocketRoute(object):
+class BaseWebSocketRoute(ABC):
 
     def __init__(self, obj: 'handler.WebSocketBase'):
         self.socket = obj
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
-        return self.socket._loop    # noqa
+        return self.socket._loop  # noqa
+
+    def _onclose(self):
+        pass
+
+    @abstractmethod
+    def is_proxied(self, method):
+        raise NotImplementedError
 
     def _resolve(self, method):
         if method.startswith('_'):
             raise AttributeError('Trying to get private method.')
 
-        if hasattr(self, method):
-            func = getattr(self, method)
-            if decorators.is_proxied(func):
-                raise NotImplementedError('Method not implemented')
-            else:
-                return func
+        if hasattr(self, method) and self.is_proxied(method):
+            return getattr(self, method)
         else:
             raise NotImplementedError('Method not implemented')
 
-    def _onclose(self):
-        pass
+
+class WebSocketRoute(BaseWebSocketRoute):
+    _NOPROXY = []
 
     @classmethod
-    def placebo(*args, **kwargs):
+    def noproxy(cls, func):
+        def wrap(*args, **kwargs):
+            if func not in cls._NOPROXY:
+                cls._NOPROXY.append(func)
+                wrap(*args, **kwargs)
+
+            return func(*args, **kwargs)
+        return wrap
+
+    @abstractmethod
+    def is_proxied(self, method):
+        func = getattr(self, method)
+        return not (func in decorators._NOPROXY)
+
+    def placebo(self, *args, **kwargs):
         log.debug("PLACEBO IS CALLED!!! args: %r, kwargs: %r", args, kwargs)
 
 
-__all__ = 'WebSocketRoute',
+class WebSocketRouteExplicit(BaseWebSocketRoute):
+
+    @abstractmethod
+    def is_proxied(self, method):
+        func = getattr(self, method)
+        return decorators.is_proxied(func)
+
+    @decorators.proxy
+    def placebo(self, *args, **kwargs):
+        log.debug("PLACEBO IS CALLED!!! args: %r, kwargs: %r", args, kwargs)
+
+
+__all__ = 'WebSocketRoute', 'decorators'

--- a/wsrpc_aiohttp/websocket/route.py
+++ b/wsrpc_aiohttp/websocket/route.py
@@ -6,27 +6,21 @@ from . import handler       # noqa
 log = logging.getLogger("wsrpc")
 
 
-class decorators(object):
-    _NOPROXY = set([])
+class decorators:
+
+    _PROXY_ATTR = '__wsrpc_aiohttp_proxy__'
 
     @staticmethod
-    def noproxy(func):
-        decorators._NOPROXY.add(func)
-        return func
+    def proxy(f):
+        setattr(f, decorators._PROXY_ATTR, True)
+        return f
+
+    @staticmethod
+    def is_proxied(f):
+        return getattr(f, decorators._PROXY_ATTR, False)
 
 
 class WebSocketRoute(object):
-    _NOPROXY = []
-
-    @classmethod
-    def noproxy(cls, func):
-        def wrap(*args, **kwargs):
-            if func not in cls._NOPROXY:
-                cls._NOPROXY.append(func)
-                wrap(*args, **kwargs)
-
-            return func(*args, **kwargs)
-        return wrap
 
     def __init__(self, obj: 'handler.WebSocketBase'):
         self.socket = obj
@@ -41,7 +35,7 @@ class WebSocketRoute(object):
 
         if hasattr(self, method):
             func = getattr(self, method)
-            if func in decorators._NOPROXY:
+            if decorators.is_proxied(func):
                 raise NotImplementedError('Method not implemented')
             else:
                 return func
@@ -56,4 +50,4 @@ class WebSocketRoute(object):
         log.debug("PLACEBO IS CALLED!!! args: %r, kwargs: %r", args, kwargs)
 
 
-__all__ = 'WebSocketRoute', 'decorators',
+__all__ = 'WebSocketRoute',

--- a/wsrpc_aiohttp/websocket/route.py
+++ b/wsrpc_aiohttp/websocket/route.py
@@ -27,7 +27,7 @@ class decorators(object):
         return getattr(f, decorators._PROXY_ATTR, False)
 
 
-class AbstractWebSocketRoute(ABC):
+class AbstractRoute(ABC):
 
     def __init__(self, obj: 'handler.WebSocketBase'):
         self.socket = obj
@@ -53,7 +53,7 @@ class AbstractWebSocketRoute(ABC):
             raise NotImplementedError('Method not implemented')
 
 
-class BaseWebSocketRoute(AbstractWebSocketRoute):
+class Route(AbstractRoute):
 
     @abstractmethod
     def proxy(self, method):
@@ -65,7 +65,7 @@ class BaseWebSocketRoute(AbstractWebSocketRoute):
         log.debug("PLACEBO IS CALLED!!! args: %r, kwargs: %r", args, kwargs)
 
 
-class LegacyWebSocketRoute(BaseWebSocketRoute):
+class LegacyRoute(Route):
     _NOPROXY = []
 
     @classmethod
@@ -84,10 +84,10 @@ class LegacyWebSocketRoute(BaseWebSocketRoute):
         return not (func in decorators._NOPROXY)
 
 
-WebSocketRoute = LegacyWebSocketRoute
+WebSocketRoute = LegacyRoute
 
 
 __all__ = (
-    'AbstractWebSocketRoute', 'BaseWebSocketRoute',
-    'WebSocketRoute', 'LegacyWebSocketRoute', 'decorators',
+    'AbstractRoute', 'Route',
+    'WebSocketRoute', 'LegacyRoute', 'decorators',
 )


### PR DESCRIPTION
For now, if custom `WebSocketRoute` is mixed with some other class with public methods, they will be automatically proxied, which may not be possible to control using `@decorators.noproxy`, thus, possibly, becoming a security flaw. I propose breaking changes, where by default no methods are proxied and those that needed to be, must be decorated with `@decorators.proxy` explicitly.