### PR TITLE
Use rsplit instead of split

### DIFF
--- a/wsrpc_aiohttp/websocket/common.py
+++ b/wsrpc_aiohttp/websocket/common.py
@@ -332,7 +332,7 @@ class WSRPCBase:
 
     def resolver(self, func_name):
         class_name, method = (
-            func_name.split(".", 1)
+            func_name.rsplit(".", 1)
             if "." in func_name
             else (func_name, "init")
         )


### PR DESCRIPTION
This make possible registration of nested routes:

```python
WebSocketHandler.add_route("uploader.pdf", PdfUploaderRoute)
```