### PR TITLE
use _dumps

### DIFF
--- a/wsrpc_aiohttp/websocket/handler.py
+++ b/wsrpc_aiohttp/websocket/handler.py
@@ -202,7 +202,7 @@ class WebSocketBase(WSRPCBase, AbstractView):
                 Lazy(lambda: str(kwargs.get("id"))),
                 Lazy(lambda: str(kwargs)),
             )
-            await self.socket.send_json(kwargs, dumps=self._json_dumps)
+            await self.socket.send_json(kwargs, dumps=self._dumps)
         except aiohttp.WebSocketError:
             self._create_task(self.close())
 


### PR DESCRIPTION
Now
`_damps` is not used, 
so you need to manually cast the complex types instead of 
```
@serializer.register(Decimal)
def convert_decimal(value: Decimal):
    return str(value)
```